### PR TITLE
Validate input names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,4 +20,5 @@ e2e: install
 	NO_INSTALL=1 ./tests/secrets/test.sh
 	NO_INSTALL=1 ./tests/environments/test.sh
 	NO_INSTALL=1 ./tests/retries/test.sh
+	NO_INSTALL=1 ./tests/validation/test.sh
 

--- a/lib/release/tracker.go
+++ b/lib/release/tracker.go
@@ -672,7 +672,12 @@ func (r *ReleaseTracker) Run(
 		log.Info("Recording pending function", "id", nextFunction.ID, "fn", nextFunction.Fn)
 		nextFnRef := fnRef.SetSubPath(strings.Split(fnRef.SubPath, "/functions/")[0] + "/functions/" + string(nextFunction.ID))
 		if err := UpdateFunctionStateUnderRef(ctx, r.stateStore.Store, nextFnRef, nextFunction); err != nil {
-			return result, fmt.Errorf("failed to update function state: %w", err)
+			log.Error("failed to update function state", "error", err)
+			fn.Status = models.StatusFailed
+			logger(sdk.Log{
+				Timestamp: time.Now(),
+				Message:   err.Error(),
+			})
 		}
 	}
 

--- a/tests/validation/badinputs.ocu.star
+++ b/tests/validation/badinputs.ocu.star
@@ -1,0 +1,15 @@
+ocuroot("0.3.0")
+
+def foo(ctx):
+    print(ctx)
+    return done()
+
+phase(
+    name="foo",
+    work=[call(foo, name="foo",
+        inputs={
+            "0startswithnumber": "a",
+            "bad-input": "b",
+        },
+    )],
+)

--- a/tests/validation/badinputsinnext.ocu.star
+++ b/tests/validation/badinputsinnext.ocu.star
@@ -1,0 +1,20 @@
+ocuroot("0.3.0")
+
+def foo(ctx):
+    print(ctx)
+    return next(
+        bar, 
+        inputs={
+            "0startswithnumber": "a",
+            "bad-input": "b",
+        },
+    )
+
+def bar(ctx):
+    print(ctx)
+    return done()
+
+phase(
+    name="foo",
+    work=[call(foo, name="foo")],
+)

--- a/tests/validation/repo.ocu.star
+++ b/tests/validation/repo.ocu.star
@@ -1,0 +1,5 @@
+ocuroot("0.3.0")
+
+store.set(
+    store.fs(".store"),
+)

--- a/tests/validation/test.sh
+++ b/tests/validation/test.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+source $(dirname "$0")/../test_helpers.sh
+
+bad_inputs() {
+    setup_test
+
+    ocuroot release new badinputs.ocu.star
+    assert_not_equal "0" "$?" "Expected a failure"
+
+    ocuroot release new badinputsinnext.ocu.star
+    assert_not_equal "0" "$?" "Expected a failure"
+
+    echo "Test passed"
+}
+
+setup_test() {
+    rm -rf .store
+}
+
+build_ocuroot
+
+pushd "$(dirname "$0")" > /dev/null
+bad_inputs
+popd > /dev/null


### PR DESCRIPTION
Input names must be valid Starlark identifiers.

Names are checked when creating new function definitions. This will happen either on initializing a release, or adding a function to a chaing from a next(...) call.

See: https://github.com/bazelbuild/starlark/blob/master/spec.md#lexical-elements

Fix #6