### PR TITLE
Add 'ocuroot work any'

### DIFF
--- a/client/commands/release.go
+++ b/client/commands/release.go
@@ -85,7 +85,7 @@ var NewReleaseCmd = &cobra.Command{
 					return err
 				}
 
-				if err := state.ApplyIntent(ctx, tc2); err != nil {
+				if err := state.ApplyIntent(ctx, tc2.Ref, tc2.Store); err != nil {
 					return err
 				}
 

--- a/client/commands/state.go
+++ b/client/commands/state.go
@@ -226,7 +226,7 @@ var StateApplyIntentCmd = &cobra.Command{
 
 		cmd.SilenceUsage = true
 
-		if err := state.ApplyIntent(ctx, tc); err != nil {
+		if err := state.ApplyIntent(ctx, tc.Ref, tc.Store); err != nil {
 			return fmt.Errorf("failed to apply intent: %w", err)
 		}
 

--- a/client/state/diff.go
+++ b/client/state/diff.go
@@ -104,7 +104,7 @@ func compareExplicitIntent(
 		if err == refstore.ErrRefNotFound {
 			return false, nil
 		}
-		return false, fmt.Errorf("failed to get state content: %w")
+		return false, fmt.Errorf("failed to get state content: %w", err)
 	}
 
 	if !reflect.DeepEqual(intentContent, stateContent) {

--- a/client/state/sync.go
+++ b/client/state/sync.go
@@ -1,0 +1,29 @@
+package state
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ocuroot/ocuroot/refs"
+	"github.com/ocuroot/ocuroot/refs/refstore"
+)
+
+// Sync identifies all diffs and applies them
+func Sync(ctx context.Context, store refstore.Store) error {
+	diffs, err := Diff(ctx, store)
+	if err != nil {
+		return fmt.Errorf("failed to get diffs: %w", err)
+	}
+
+	for _, diff := range diffs {
+		diffRef, err := refs.Parse(diff)
+		if err != nil {
+			return fmt.Errorf("failed to parse diff ref: %w", err)
+		}
+		if err := ApplyIntent(ctx, diffRef, store); err != nil {
+			return fmt.Errorf("failed to apply intent: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/tests/ci/repo/continue.sh
+++ b/tests/ci/repo/continue.sh
@@ -3,6 +3,5 @@
 export OCUROOT_HOME=$(mktemp -d)
 echo "OCUROOT_HOME: $OCUROOT_HOME"
 
-ocuroot work continue
-ocuroot state diff | xargs -r -n1 ocuroot state apply
-ocuroot work trigger
+# Run the omnibus command to perform any outstanding work for this commit
+ocuroot work any

--- a/tests/ci/repo/release.ocu.star
+++ b/tests/ci/repo/release.ocu.star
@@ -10,7 +10,12 @@ def build(ctx):
 
 def up(ctx):
     print("Deploying to {}".format(ctx.inputs.environment["name"]))
-    return done()
+    print("foo: {}".format(ctx.inputs.foo))
+    return done(
+        outputs={
+            "foo": ctx.inputs.foo,
+        }
+    )
 
 def down(ctx):
     print("Undeploying from {}".format(ctx.inputs.environment["name"]))
@@ -28,6 +33,9 @@ phase(
             up=up,
             down=down,
             environment=environment,
+            inputs={
+                "foo": input(ref="@/custom/foo", default="bar"),
+            }
         ) for environment in staging
     ],
 )
@@ -39,6 +47,9 @@ phase(
             up=up,
             down=down,
             environment=environment,
+            inputs={
+                "foo": input(ref="@/custom/foo", default="bar"),
+            }
         ) for environment in prod
     ],
 )

--- a/tests/ci/repo/repo.ocu.star
+++ b/tests/ci/repo/repo.ocu.star
@@ -20,6 +20,7 @@ def setup_store():
         store.set(state_store, intent=intent_store)
 
 def do_trigger(commit):
+    print("triggering for commit:" + commit)
     git_remote_res = host.shell("git remote get-url origin", continue_on_error=True)
     git_remote = git_remote_res.stdout.strip()
     http.post("http://localhost:8081/api/jobs", body=json.encode({"repo_uri": git_remote, "commit": commit, "command": "./continue.sh"}))

--- a/tests/ci/test_helpers.sh
+++ b/tests/ci/test_helpers.sh
@@ -189,6 +189,14 @@ job_logs() {
     echo $logs_response | jq -r '.logs[]'
 }
 
+all_job_logs() {
+    local jobs_response=$(curl -s "http://localhost:$CI_PORT/api/jobs")
+    for job_id in $(echo $jobs_response | jq -r '.jobs[]'); do
+        echo "Logs for job $job_id:"
+        job_logs "$job_id"
+    done
+}
+
 job_status() {
     local job_id=$1
     local job_response=$(curl -s "http://localhost:$CI_PORT/api/jobs/$job_id")

--- a/tests/environments/repo.ocu.star
+++ b/tests/environments/repo.ocu.star
@@ -4,3 +4,19 @@ store.set(
     store.fs(".store/state"),
     intent=store.fs(".store/intent"),
 )
+
+# Recursively trigger additional work
+# Limited to 5 levels of recursion
+def _trigger(commit):
+    if "TRIGGER_DEPTH" in host.env():
+        trigger_depth = int(host.env()["TRIGGER_DEPTH"])
+    else:
+        trigger_depth = 5
+
+    if trigger_depth <= 0:
+        fail("Trigger depth exceeded")
+
+    print("triggering for commit:" + commit)
+    host.shell("ocuroot work any", env={"TRIGGER_DEPTH": str(trigger_depth - 1)})
+
+trigger(_trigger)


### PR DESCRIPTION
This command combines all commands that take work from the state/intent stores.

Work is executed in this order:
* Release work (calls, deploys)
* Tasks
* Applying out-if-sync intent
* Triggering any follow-on work

CI and environment tests have been extended to validate this behavior.