### PR TITLE
Track commit summaries for release notes

### DIFF
--- a/release.ocu.star
+++ b/release.ocu.star
@@ -160,7 +160,7 @@ def release(ctx):
     commit_summaries=ctx.inputs.commit_summaries,
 )
 
-    host.shell("gh release create {version} --target {target} --title {version} --notes \"$RELEASE_NOTES\"".format(
+    host.shell("gh release create {version} --target {target} --title \"v{version}\" --notes \"$RELEASE_NOTES\"".format(
         version=version,
         target=target,
     ), env={"RELEASE_NOTES": release_notes})


### PR DESCRIPTION
Build a list of commits through each candidate release and include in release notes.

Fix #22 