### PR TITLE
Allow support files to be added to git state stores

### DIFF
--- a/client/release/tracker.go
+++ b/client/release/tracker.go
@@ -12,10 +12,11 @@ import (
 )
 
 type TrackerConfig struct {
-	Commit   string
-	RepoPath string
-	Ref      refs.Ref
-	Store    refstore.Store
+	Commit      string
+	RepoPath    string
+	Ref         refs.Ref
+	Store       refstore.Store
+	StoreConfig *sdk.Store
 }
 
 func TrackerForNewRelease(ctx context.Context, tc TrackerConfig) (*release.ReleaseTracker, []sdk.Environment, error) {

--- a/refs/refstore/gitrefstore_test.go
+++ b/refs/refstore/gitrefstore_test.go
@@ -131,3 +131,59 @@ func TestGitRefStoreTransaction(t *testing.T) {
 		t.Fatalf("expected test, got %s", got)
 	}
 }
+
+func TestGitRefStoreAddSupportFiles(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "ocuroot_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		os.RemoveAll(tempDir)
+	})
+
+	remotePath, cleanup, err := gittools.CreateTestRemoteRepo("ocuroot_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(cleanup)
+
+	localPath := filepath.Join(tempDir, "local_repo")
+
+	store, err := NewGitRefStore(localPath, remotePath, "master")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := store.Close(); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	ctx := context.Background()
+
+	if err := store.AddSupportFiles(ctx, map[string]string{
+		".github/workflows/ocuroot.yml": "name: ocuroot\n",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	checkoutTempDir, err := os.MkdirTemp("", "ocuroot_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if false {
+		t.Cleanup(func() {
+			os.RemoveAll(checkoutTempDir)
+		})
+	}
+	_, err = gittools.NewClient().Clone(remotePath, checkoutTempDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	filePath := filepath.Join(checkoutTempDir, ".github", "workflows", "ocuroot.yml")
+	if _, err := os.Stat(filePath); err != nil {
+		t.Fatalf("expected file %s to exist, but got error %s", filePath, err)
+	}
+
+}

--- a/sdk/backend.go
+++ b/sdk/backend.go
@@ -137,8 +137,9 @@ type Store struct {
 
 type StorageBackend struct {
 	Git *struct {
-		RemoteURL string `json:"remote_url"`
-		Branch    string `json:"branch"`
+		RemoteURL    string            `json:"remote_url"`
+		Branch       string            `json:"branch"`
+		SupportFiles map[string]string `json:"support_files,omitempty"`
 	} `json:"git,omitempty"`
 	Fs *struct {
 		Path string `json:"path"`

--- a/sdk/sdk/0.3.0/store.star
+++ b/sdk/sdk/0.3.0/store.star
@@ -13,7 +13,7 @@ def _set_store(state,intent=None):
     """
     backend.store.set(json.encode({"state": state, "intent": intent}))
 
-def _git_store(remote_url, branch=None):
+def _git_store(remote_url, branch=None, support_files=None):
     """
     Creates a git store for the given remote URL.
     
@@ -28,6 +28,8 @@ def _git_store(remote_url, branch=None):
         "git": {
             "remote_url": remote_url,
             "branch": branch,
+            # TODO: Should this accept a function?
+            "support_files": support_files,
         }
     }
 

--- a/tests/gitstate/repo.ocu.star
+++ b/tests/gitstate/repo.ocu.star
@@ -5,8 +5,8 @@ repo_alias("gitstate/repo")
 env_vars = host.env()
 
 store.set(
-    store.git(env_vars["STATE_REMOTE"]),
-    intent=store.git(env_vars["INTENT_REMOTE"]),
+    store.git(env_vars["STATE_REMOTE"], support_files={"support.txt": "state"}),
+    intent=store.git(env_vars["INTENT_REMOTE"], support_files={"support.txt": "intent"}),
 )
 
 def do_trigger(commit):

--- a/tests/gitstate/test.sh
+++ b/tests/gitstate/test.sh
@@ -52,6 +52,12 @@ test_gitstate() {
     assert_not_deployed "basic.ocu.star" "production"
     assert_deployed "basic.ocu.star" "production2"
 
+    echo "== check for files in state store =="
+    check_file_in_remote "$STATE_REMOTE" "support.txt" "state"
+
+    echo "== check for files in intent store =="
+    check_file_in_remote "$INTENT_REMOTE" "support.txt" "intent"
+
     echo "Test succeeded"
     echo ""
 }

--- a/tests/gitstate/test_helpers.sh
+++ b/tests/gitstate/test_helpers.sh
@@ -47,3 +47,22 @@ init_working_dir() {
     git -C "$working_dir" commit --allow-empty -m "Initial commit"
     git -C "$working_dir" push origin HEAD:main
 }
+
+
+# Check if a file exists in a remote repo and has specific content
+check_file_in_remote() {
+    local remote_url="$1"
+    local file_path="$2"
+    local expected_content="$3"
+    
+    local tmp_dir=$(mktemp -d)
+    trap "rm -rf $tmp_dir" EXIT
+    git clone "$remote_url" "$tmp_dir"
+    local file_content=$(cat "$tmp_dir/$file_path")
+    if [ "$file_content" == "$expected_content" ]; then
+        return 0
+    else
+        echo "File content does not match expected content"
+        exit 1
+    fi
+}


### PR DESCRIPTION
When defining a git store, a map of support file paths to contents can be provided.

These support files will be added to each git store if this is the first time we've seen this commit.

Included testing to verify the contents of the file in each repo.

Fix #19