### PR TITLE
Fix issue with args & kwargs in tasks/deploys

### DIFF
--- a/sdk/sdk/0.3.0/dowork.star
+++ b/sdk/sdk/0.3.0/dowork.star
@@ -30,7 +30,7 @@ def check_params(
     # check that every fArg is represented in inputs
     for k in fArgs:
         if k not in inputs:
-            fail("Function parameter '" + k + "' is not present in inputs and has no default value for '" + str(fName) + "' at " + str(fPos))
+            fail("Function parameter '" + k + "' is not present in inputs and has no default value for '" + str(fName) + "' at " + str(fPos) + "inputs=" + str(inputs))
     
 
 def _do_work(

--- a/tests/ci/repo/backend.ocu.star
+++ b/tests/ci/repo/backend.ocu.star
@@ -4,7 +4,7 @@ envs = environments()
 staging = [e for e in envs if e.attributes["type"] == "staging"]
 prod = [e for e in envs if e.attributes["type"] == "prod"]
 
-def build(ctx):
+def build():
     print("Building")
     res = host.shell("cat message-backend.txt", mute=True)
     print("Message: {}".format(res.stdout))
@@ -15,27 +15,27 @@ def build(ctx):
         },
     )
 
-def up(ctx):
-    print("Deploying to {}".format(ctx.inputs.environment["name"]))
+def up(environment, message):
+    print("Deploying to {}".format(environment["name"]))
     return done(
         outputs={
-            "message": ctx.inputs.message,
+            "message": message,
             "foo": "bar",
         },
     )
 
-def down(ctx):
-    print("Undeploying from {}".format(ctx.inputs.environment["name"]))
+def down(environment, message):
+    print("Undeploying from {}".format(environment["name"]))
     return done()
 
 phase(
     name="build",
-    work=[call(build, name="build")],
+    tasks=[task(build, name="build")],
 )
 
 phase(
     name="staging",
-    work=[
+    tasks=[
         deploy(
             up=up,
             down=down,
@@ -49,7 +49,7 @@ phase(
 
 phase(
     name="prod",
-    work=[
+    tasks=[
         deploy(
             up=up,
             down=down,

--- a/tests/ci/repo/frontend.ocu.star
+++ b/tests/ci/repo/frontend.ocu.star
@@ -4,7 +4,7 @@ envs = environments()
 staging = [e for e in envs if e.attributes["type"] == "staging"]
 prod = [e for e in envs if e.attributes["type"] == "prod"]
 
-def build(ctx):
+def build():
     print("Building")
     res = host.shell("cat message-frontend.txt", mute=True)
     print("Message: {}".format(res.stdout))
@@ -15,30 +15,29 @@ def build(ctx):
         },
     )
 
-def up(ctx):
-    print("Deploying to {}".format(ctx.inputs.environment["name"]))
-    print("foo = {}".format(ctx.inputs.foo))
-    print("Message: {}".format(ctx.inputs.message))
+def up(environment, foo, message, backend_message):
+    print("Deploying to {}".format(environment["name"]))
+    print("foo = {}".format(foo))
+    print("Message: {}".format(message))
     return done(
         outputs={
-            "backend_message": ctx.inputs.backend_message,
-            "message": ctx.inputs.message,
+            "backend_message": backend_message,
+            "message": message,
         },
     )
 
-def down(ctx):
-    print("Undeploying from {}".format(ctx.inputs.environment["name"]))
-    print("Message: {}".format(ctx.inputs.message))
+def down(environment, foo, message, backend_message):
+    print("Undeploying from {}".format(environment["name"]))
     return done()
 
 phase(
     name="build",
-    work=[call(build, name="build")],
+    tasks=[task(build, name="build")],
 )
 
 phase(
     name="staging",
-    work=[
+    tasks=[
         deploy(
             up=up,
             down=down,
@@ -54,7 +53,7 @@ phase(
 
 phase(
     name="prod",
-    work=[
+    tasks=[
         deploy(
             up=up,
             down=down,

--- a/tests/ci/repo/release.ocu.star
+++ b/tests/ci/repo/release.ocu.star
@@ -4,31 +4,31 @@ envs = environments()
 staging = [e for e in envs if e.attributes["type"] == "staging"]
 prod = [e for e in envs if e.attributes["type"] == "prod"]
 
-def build(ctx):
+def build():
     print("Building")
     return done()
 
-def up(ctx):
-    print("Deploying to {}".format(ctx.inputs.environment["name"]))
-    print("foo: {}".format(ctx.inputs.foo))
+def up(environment, foo):
+    print("Deploying to {}".format(environment["name"]))
+    print("foo: {}".format(foo))
     return done(
         outputs={
-            "foo": ctx.inputs.foo,
+            "foo": foo,
         }
     )
 
-def down(ctx):
-    print("Undeploying from {}".format(ctx.inputs.environment["name"]))
+def down(environment, foo):
+    print("Undeploying from {}".format(environment["name"]))
     return done()
 
 phase(
     name="build",
-    work=[call(build, name="build")],
+    tasks=[task(build, name="build")],
 )
 
 phase(
     name="staging",
-    work=[
+    tasks=[
         deploy(
             up=up,
             down=down,
@@ -42,7 +42,7 @@ phase(
 
 phase(
     name="prod",
-    work=[
+    tasks=[
         deploy(
             up=up,
             down=down,

--- a/tests/dependencies/backend/package.ocu.star
+++ b/tests/dependencies/backend/package.ocu.star
@@ -12,33 +12,33 @@ def setup_deploy(environment):
         }
     )
 
-def up(ctx):
+def up(environment, credential):
     return done(outputs={
-        "host": "{}.backend.example.com".format(ctx.inputs.environment["name"]),
-        "credential": ctx.inputs.credential,
+        "host": "{}.backend.example.com".format(environment["name"]),
+        "credential": credential,
     })
 
-def down(ctx):
+def down(environment, credential):
     return done()
 
-def build(ctx):
+def build():
     return done()
 
 phase(
     name="build",
-    work=[call(fn=build, name="build")],
+    tasks=[task(fn=build, name="build")],
 )
 
 phase(
     name="staging",
-    work=[
+    tasks=[
         setup_deploy(e) for e in envs if e.attributes["type"] == "staging"
     ],
 )
         
 phase(
     name="prod",
-    work=[
+    tasks=[
         setup_deploy(e) for e in envs if e.attributes["type"] == "prod"
     ],
 )

--- a/tests/dependencies/frontend/package.ocu.star
+++ b/tests/dependencies/frontend/package.ocu.star
@@ -8,40 +8,38 @@ def setup_deploy(environment):
         down=down,
         environment=environment,
         inputs={
-            "backend_host": ref("./-/backend/package.ocu.star/@/deploy/{}#output/host".format(environment.name)),
             "backend_credential": ref("./-/backend/package.ocu.star/@/deploy/{}#output/credential".format(environment.name)),
         }
     )
 
-def up(ctx):
+def up(environment, backend_credential):
     print("up")
-    print(ctx)
     return done(
         outputs={
-            "host": "{}.frontend.example.com".format(ctx.inputs.environment["name"]),
-            "backend_credential": ctx.inputs.backend_credential,
+            "host": "{}.frontend.example.com".format(environment["name"]),
+            "backend_credential": backend_credential,
         }
     )
 
-def down(ctx):
+def down(environment, backend_credential):
     return done()
 
-def build(ctx):
+def build():
     return done()
 
 phase(
     name="build",
-    work=[call(fn=build, name="build")],
+    tasks=[task(fn=build, name="build")],
 )
 phase(
     name="staging",
-    work=[
+    tasks=[
         setup_deploy(e) for e in envs if e.attributes["type"] == "staging"
     ],
 )
 phase(
     name="prod",
-    work=[
+    tasks=[
         setup_deploy(e) for e in envs if e.attributes["type"] == "prod"
     ],
 )

--- a/tests/environments/package1.ocu.star
+++ b/tests/environments/package1.ocu.star
@@ -1,21 +1,21 @@
 ocuroot("0.3.0")
 
-def up(ctx):
+def up(environment):
     print("package1 up")
-    write("./.deploys/{}/package1.txt".format(ctx.inputs.environment["name"]), str(ctx))
+    write("./.deploys/{}/package1.txt".format(environment["name"]), str(environment))
     return done()
 
-def down(ctx):
+def down(environment):
     print("package1 down")
-    content = read("./.deploys/{}/package1.txt".format(ctx.inputs.environment["name"]))
-    if content != str(ctx):
+    content = read("./.deploys/{}/package1.txt".format(environment["name"]))
+    if content != str(environment):
         return fail("content does not match")
-    shell("rm -f ./.deploys/{}/package1.txt".format(ctx.inputs.environment["name"]))
+    shell("rm -f ./.deploys/{}/package1.txt".format(environment["name"]))
     return done()
 
 phase(
     "deploy",
-    work=[
+    tasks=[
         deploy(
             up=up,
             down=down,

--- a/tests/environments/package2.ocu.star
+++ b/tests/environments/package2.ocu.star
@@ -1,22 +1,22 @@
 ocuroot("0.3.0")
 
-def up(ctx):
+def up(environment):
     print("package2 up")
-    write("./.deploys/{}/package2.txt".format(ctx.inputs.environment["name"]), str(ctx))
+    write("./.deploys/{}/package2.txt".format(environment["name"]), str(environment))
     return done()
 
-def down(ctx):
+def down(environment):
     print("package2 down")
-    content = read("./.deploys/{}/package2.txt".format(ctx.inputs.environment["name"]))
-    if content != str(ctx):
+    content = read("./.deploys/{}/package2.txt".format(environment["name"]))
+    if content != str(environment):
         return fail("content does not match")
-    shell("rm -f ./.deploys/{}/package2.txt".format(ctx.inputs.environment["name"]))
+    shell("rm -f ./.deploys/{}/package2.txt".format(environment["name"]))
     return done()
 
 
 phase(
     "deploy",
-    work=[
+    tasks=[
         deploy(
             up=up,
             down=down,

--- a/tests/errors/package.ocu.star
+++ b/tests/errors/package.ocu.star
@@ -8,12 +8,12 @@ prod = [e for e in envs if e.attributes["type"] == "prod"]
 
 phase(
     name="build",
-    work=[call(build, name="build")],
+    tasks=[task(build, name="build")],
 )
 
 phase(
     name="staging",
-    work=[
+    tasks=[
         deploy(
             up=up,
             down=down,
@@ -31,7 +31,7 @@ phase(
 
 phase(
     name="prod",
-    work=[
+    tasks=[
         deploy(
             up=up,
             down=down,

--- a/tests/errors/tasks.ocu.star
+++ b/tests/errors/tasks.ocu.star
@@ -1,8 +1,7 @@
 ocuroot("0.3.0")
 
-def build(ctx):
+def build():
     print("Building minimal package")
-    print(ctx)
 
     res = host.shell("pwd", mute=True)
     print("Current directory: ", res.stdout.strip())
@@ -24,26 +23,24 @@ def build(ctx):
         },
     )
 
-def up(ctx):
+def up(environment, previous_count, input1, staging_name=""):
     print("Deploying minimal package")    
-    print("ctx: ", ctx)
-    print("Environment: ", ctx.inputs.environment["name"])
+    print("Environment: ", environment["name"])
     outputs = {}
-    outputs["count"] = ctx.inputs.previous_count + 1
-    outputs["env_name"] = ctx.inputs.environment
-    outputs["input1"] = ctx.inputs.input1
+    outputs["count"] = previous_count + 1
+    outputs["env_name"] = environment
+    outputs["input1"] = input1
 
     # Output some log lines and force a pause
     for i in range(1,10):
         host.shell("sleep 0.1")
         print("Log line number " + str(i))
 
-    if ctx.inputs.environment["name"] == "production2":
+    if environment["name"] == "production2":
         fail("something is wrong in production2")
 
     return done(outputs=outputs)
 
-def down(ctx):
+def down(environment, previous_count, input1, staging_name=""):
     print("Destroying minimal package")
-    print(ctx)
     return done()

--- a/tests/gitstate/basic.ocu.star
+++ b/tests/gitstate/basic.ocu.star
@@ -8,12 +8,12 @@ prod = [e for e in envs if e.attributes["type"] == "prod"]
 
 phase(
     name="build",
-    work=[call(build, name="build")],
+    tasks=[task(build, name="build")],
 )
 
 phase(
     name="staging",
-    work=[
+    tasks=[
         deploy(
             up=up,
             down=down,
@@ -31,7 +31,7 @@ phase(
 
 phase(
     name="prod",
-    work=[
+    tasks=[
         deploy(
             up=up,
             down=down,

--- a/tests/gitstate/tasks.ocu.star
+++ b/tests/gitstate/tasks.ocu.star
@@ -1,8 +1,7 @@
 ocuroot("0.3.0")
 
-def build(ctx):
+def build():
     print("Building minimal package")
-    print(ctx)
 
     res = host.shell("pwd", mute=True)
     print("Current directory: ", res.stdout)
@@ -20,14 +19,13 @@ def build(ctx):
         },
     )
 
-def up(ctx):
+def up(environment, previous_count, input1, staging_name=""):
     print("Deploying minimal package")    
-    print("ctx: ", ctx)
-    print("Environment: ", ctx.inputs.environment["name"])
+    print("Environment: ", environment["name"])
     outputs = {}
-    outputs["count"] = ctx.inputs.previous_count + 1
-    outputs["environment"] = ctx.inputs.environment
-    outputs["input1"] = ctx.inputs.input1
+    outputs["count"] = previous_count + 1
+    outputs["environment"] = environment
+    outputs["input1"] = input1
 
     # Output some log lines and force a pause
     for i in range(1,5):
@@ -36,13 +34,12 @@ def up(ctx):
 
     return next(up_stage2, inputs=outputs)
 
-def up_stage2(ctx):
-    print("Continuing deploy to ", ctx.inputs.environment["name"])
-    print(ctx.inputs.input1)
-    return done(outputs={"env_name": ctx.inputs.environment["name"], "count": ctx.inputs.count}, tags=["v"+str(ctx.inputs.count)])
+def up_stage2(count, environment, input1):
+    print("Continuing deploy to ", environment["name"])
+    print(input1)
+    return done(outputs={"env_name": environment["name"], "count": count}, tags=["v"+str(count)])
 
-def down(ctx):
+def down(environment, previous_count, input1, staging_name=""):
     print("Destroying minimal package")
-    print(ctx)
-    print("Environment: " + ctx.inputs.environment["name"])
+    print("Environment: " + environment["name"])
     return done()

--- a/tests/gitstate_shared/basic.ocu.star
+++ b/tests/gitstate_shared/basic.ocu.star
@@ -8,12 +8,12 @@ prod = [e for e in envs if e.attributes["type"] == "prod"]
 
 phase(
     name="build",
-    work=[call(build, name="build")],
+    tasks=[task(build, name="build")],
 )
 
 phase(
     name="staging",
-    work=[
+    tasks=[
         deploy(
             up=up,
             down=down,
@@ -31,7 +31,7 @@ phase(
 
 phase(
     name="prod",
-    work=[
+    tasks=[
         deploy(
             up=up,
             down=down,

--- a/tests/gitstate_shared/tasks.ocu.star
+++ b/tests/gitstate_shared/tasks.ocu.star
@@ -1,8 +1,7 @@
 ocuroot("0.3.0")
 
-def build(ctx):
+def build():
     print("Building minimal package")
-    print(ctx)
 
     res = host.shell("pwd", mute=True)
     print("Current directory: ", res.stdout)
@@ -20,14 +19,13 @@ def build(ctx):
         },
     )
 
-def up(ctx):
+def up(environment, previous_count, input1, staging_name=""):
     print("Deploying minimal package")    
-    print("ctx: ", ctx)
-    print("Environment: ", ctx.inputs.environment["name"])
+    print("Environment: ", environment["name"])
     outputs = {}
-    outputs["count"] = ctx.inputs.previous_count + 1
-    outputs["environment"] = ctx.inputs.environment
-    outputs["input1"] = ctx.inputs.input1
+    outputs["count"] = previous_count + 1
+    outputs["environment"] = environment
+    outputs["input1"] = input1
 
     # Output some log lines and force a pause
     for i in range(1,5):
@@ -36,13 +34,12 @@ def up(ctx):
 
     return next(up_stage2, inputs=outputs)
 
-def up_stage2(ctx):
-    print("Continuing deploy to ", ctx.inputs.environment["name"])
-    print(ctx.inputs.input1)
-    return done(outputs={"env_name": ctx.inputs.environment["name"], "count": ctx.inputs.count}, tags=["v"+str(ctx.inputs.count)])
+def up_stage2(count, environment, input1):
+    print("Continuing deploy to ", environment["name"])
+    print(input1)
+    return done(outputs={"env_name": environment["name"], "count": count}, tags=["v"+str(count)])
 
-def down(ctx):
+def down(environment, previous_count, input1, staging_name=""):
     print("Destroying minimal package")
-    print(ctx)
-    print("Environment: " + ctx.inputs.environment["name"])
+    print("Environment: " + environment["name"])
     return done()

--- a/tests/minimal/approvals.ocu.star
+++ b/tests/minimal/approvals.ocu.star
@@ -8,12 +8,12 @@ prod = [e for e in envs if e.attributes["type"] == "prod"]
 
 phase(
     name="build",
-    work=[call(build, name="build")],
+    tasks=[task(build, name="build")],
 )
 
 phase(
     name="staging",
-    work=[
+    tasks=[
         deploy(
             up=up,
             down=down,
@@ -29,15 +29,14 @@ phase(
     ],
 )
 
-def check(ctx):
+def check(input1, staging_name):
     print("Checking call input")
-    print(ctx)
     return done()
 
 phase(
     name="call input check",
-    work=[
-        call(
+    tasks=[
+        task(
             fn=check,
             name="check",
             inputs={
@@ -49,7 +48,7 @@ phase(
 )
 
 # Require a second approval to proceed
-def approve(ctx):
+def approve(approval):
     return next(
         fn=_noop,
         inputs={
@@ -59,13 +58,13 @@ def approve(ctx):
         },
     )
 
-def _noop(ctx):
+def _noop(approval):
     print("Noop")
     return done()
 
 phase(
     name="prod approval",
-    work=[call(
+    tasks=[task(
         approve, 
         name="prod_approval", 
         inputs={
@@ -81,7 +80,7 @@ phase(
 
 phase(
     name="prod",
-    work=[
+    tasks=[
         deploy(
             up=up,
             down=down,

--- a/tests/minimal/basic.ocu.star
+++ b/tests/minimal/basic.ocu.star
@@ -28,7 +28,7 @@ phase(
 
 phase(
     name="prod",
-    work=[
+    tasks=[
         deploy(
             up=up,
             down=down,

--- a/tests/minimal/tasks.ocu.star
+++ b/tests/minimal/tasks.ocu.star
@@ -35,7 +35,7 @@ def build():
         },
     )
 
-def up(environment={"name": ""}, staging_name="", previous_count=0, input1=None):
+def up(environment, input1, previous_count=0, staging_name=""):
     print("Deploying minimal package")    
     print("Environment: ", environment["name"])
     outputs = {}
@@ -55,7 +55,7 @@ def up_stage2(count, environment, input1):
     print(input1)
     return done(outputs={"env_name": environment["name"], "count": count}, tags=["v"+str(count)])
 
-def down(environment={"name": ""}, staging_name="", previous_count=0, input1=None):
+def down(environment, staging_name="", previous_count=0, input1=None):
     print("Destroying minimal package")
     print("Environment: ", environment["name"])
     print("Input1: ", input1)

--- a/tests/retries/release.ocu.star
+++ b/tests/retries/release.ocu.star
@@ -1,6 +1,6 @@
 ocuroot("0.3.0")
 
-def up(ctx):
+def up(environment):
     # The first attempt to run this function will fail, as ready.txt does not exist
     # It will always succeed after this first attempt.
     # This simulates a failure that can be retried.
@@ -11,12 +11,12 @@ def up(ctx):
 
     return done()
 
-def down(ctx):
+def down(environment):
     return done()
 
 phase(
     "release",
-    work=[
+    tasks=[
         deploy(
             up=up,
             down=down,
@@ -25,7 +25,7 @@ phase(
     ],
 )
 
-def postrelease(ctx):
+def postrelease():
     return done(
         outputs={
             "foo": "bar",
@@ -34,8 +34,8 @@ def postrelease(ctx):
 
 phase(
     "postrelease",
-    work=[
-        call(
+    tasks=[
+        task(
             fn=postrelease,
             name="postrelease",
         )

--- a/tests/secrets/release.ocu.star
+++ b/tests/secrets/release.ocu.star
@@ -1,15 +1,12 @@
 ocuroot("0.3.0")
 
-def fn(ctx):
+def fn():
     value = "abc123"
     secret(value)
     print(value)
     return done()
 
-phase(
-    name="fn",
-    work=[call(fn, name="fn")],
-)
+task(fn=fn, name="fn")
 
 value2 = "def456"
 secret(value2)

--- a/tests/validation/badinputs.ocu.star
+++ b/tests/validation/badinputs.ocu.star
@@ -1,12 +1,11 @@
 ocuroot("0.3.0")
 
-def foo(ctx):
-    print(ctx)
+def foo():
     return done()
 
 phase(
     name="foo",
-    work=[call(foo, name="foo",
+    tasks=[task(foo, name="foo",
         inputs={
             "0startswithnumber": "a",
             "bad-input": "b",

--- a/tests/validation/badinputsinnext.ocu.star
+++ b/tests/validation/badinputsinnext.ocu.star
@@ -1,7 +1,6 @@
 ocuroot("0.3.0")
 
-def foo(ctx):
-    print(ctx)
+def foo():
     return next(
         bar, 
         inputs={
@@ -10,11 +9,10 @@ def foo(ctx):
         },
     )
 
-def bar(ctx):
-    print(ctx)
+def bar():
     return done()
 
 phase(
     name="foo",
-    work=[call(foo, name="foo")],
+    tasks=[task(foo, name="foo")],
 )

--- a/tests/validation/functionargs.ocu.star
+++ b/tests/validation/functionargs.ocu.star
@@ -3,7 +3,7 @@ ocuroot("0.3.0")
 def foo(i1, missing, i2="default"):
     return done()
 
-call(
+task(
     foo, 
     name="foo",
     inputs={

--- a/tests/validation/tags.ocu.star
+++ b/tests/validation/tags.ocu.star
@@ -1,7 +1,6 @@
 ocuroot("0.3.0")
 
-def foo(ctx):
-    print(ctx)
+def foo():
     return done(
         tags=[
             "invalid/tag",
@@ -10,5 +9,5 @@ def foo(ctx):
 
 phase(
     name="foo",
-    work=[call(foo, name="foo")],
+    tasks=[task(foo, name="foo")],
 )

--- a/tests/validation/tags2.ocu.star
+++ b/tests/validation/tags2.ocu.star
@@ -1,7 +1,6 @@
 ocuroot("0.3.0")
 
-def foo(ctx):
-    print(ctx)
+def foo():
     return done(
         tags=[
             "r123",
@@ -10,5 +9,5 @@ def foo(ctx):
 
 phase(
     name="foo",
-    work=[call(foo, name="foo")],
+    tasks=[task(foo, name="foo")],
 )

--- a/tests/versioning/release.ocu.star
+++ b/tests/versioning/release.ocu.star
@@ -38,8 +38,8 @@ def next_prerelease_version(prerelease, version):
     # Next prerelease for this major/minor version
     return "{}.{}.{}-{}".format(MAJOR, MINOR, ps.patch, ps.prerelease + 1)
 
-def prerelease(ctx):
-    prerelease = next_prerelease_version(ctx.inputs.prev_prerelease, ctx.inputs.prev_version)
+def prerelease(prev_prerelease, prev_version):
+    prerelease = next_prerelease_version(prev_prerelease, prev_version)
     return done(
         outputs={
             "prerelease": prerelease,
@@ -49,7 +49,7 @@ def prerelease(ctx):
 
 phase(
     name="version",
-    work=[call(
+    tasks=[task(
         prerelease, 
         name="prerelease", 
         inputs={
@@ -61,7 +61,7 @@ phase(
 
 phase(
     name="build",
-    work=[call(
+    tasks=[task(
         build, 
         name="build", 
         inputs={
@@ -72,13 +72,13 @@ phase(
 
 promotion_ref = ref("./custom/promote")
 
-def promote(ctx):
+def promote():
     print("Promoting")
     return done()
 
 phase(
     name="promote",
-    work=[call(
+    tasks=[task(
         promote, 
         name="promote", 
         inputs={
@@ -93,8 +93,8 @@ phase(
     )],
 )
 
-def release(ctx):
-    version = ctx.inputs.prerelease.split("-")[0]
+def release(prerelease):
+    version = prerelease.split("-")[0]
 
     do_release(version)
 
@@ -107,8 +107,8 @@ def release(ctx):
 
 phase(
     name="release",
-    work=[
-        call(
+    tasks=[
+        task(
             release,
             name="release",
             inputs={
@@ -118,8 +118,8 @@ phase(
     ],
 )
 
-def finalize(ctx):
-    version = ctx.inputs.prerelease.split("-")[0]
+def finalize(prerelease):
+    version = prerelease.split("-")[0]
     return done(
         outputs={
             "version": version,
@@ -128,8 +128,8 @@ def finalize(ctx):
 
 phase(
     name="finalize",
-    work=[
-        call(
+    tasks=[
+        task(
             finalize,
             name="finalize",
             inputs={

--- a/tests/versioning/tasks.ocu.star
+++ b/tests/versioning/tasks.ocu.star
@@ -1,6 +1,6 @@
 ocuroot("0.3.0")
 
-def build(ctx):
+def build():
     print("Building")
     return done()
 


### PR DESCRIPTION
The environment param was not being passed in with the input list, so not providing a default resulted in an error.

Also updated tests to use the new parameter model and replace instances of "call" with "task".

Fix #65